### PR TITLE
Adding support of *bool in constructComparisonClause method

### DIFF
--- a/marshaller.go
+++ b/marshaller.go
@@ -252,6 +252,12 @@ func constructComparisonClause(v interface{}, fieldName, operator string) (strin
 	case string:
 		useSingleQuotes = true
 		value = u
+	case *bool:
+		if u == nil {
+			// Not an error case because nil value for *bool is valid
+			return "", nil
+		}
+		value = fmt.Sprint(*u)
 	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64, bool:
 		value = fmt.Sprint(u)
 	case time.Time:

--- a/marshaller_test.go
+++ b/marshaller_test.go
@@ -348,7 +348,7 @@ var _ = Describe("Marshaller", func() {
 			})
 		})
 
-		Context("when all clauses are boolean data types", func() {
+		Context("when all clauses are boolean data types(includes nil *bool)", func() {
 			var criteria QueryCriteriaWithBooleanType
 			BeforeEach(func() {
 				criteria = QueryCriteriaWithBooleanType{
@@ -359,12 +359,34 @@ var _ = Describe("Marshaller", func() {
 				expectedClause = "NUMA_Enabled__c = true AND Disable_Alerts__c = false"
 			})
 
+			It("returns properly formed clause joined by AND clause, ignores nil", func() {
+				clause, err = MarshalWhereClause(criteria)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(clause).To(Equal(expectedClause))
+			})
+		})
+
+		Context("when all clauses are boolean data types(includes non nil *bool)", func() {
+			var criteria QueryCriteriaWithBooleanType
+			BeforeEach(func() {
+				enableLogging := true
+
+				criteria = QueryCriteriaWithBooleanType{
+					NUMAEnabled:   true,
+					DisableAlerts: false,
+					EnableLogging: &enableLogging,
+				}
+
+				expectedClause = "NUMA_Enabled__c = true AND Disable_Alerts__c = false AND Enable_Logging__c = true"
+			})
+
 			It("returns properly formed clause joined by AND clause", func() {
 				clause, err = MarshalWhereClause(criteria)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(clause).To(Equal(expectedClause))
 			})
 		})
+
 
 		Context("when all clauses are date time data types", func() {
 			var criteria QueryCriteriaWithDateTimeType

--- a/soql_suite_test.go
+++ b/soql_suite_test.go
@@ -189,6 +189,7 @@ type QueryCriteriaWithFloatTypes struct {
 type QueryCriteriaWithBooleanType struct {
 	NUMAEnabled   bool `soql:"equalsOperator,fieldName=NUMA_Enabled__c"`
 	DisableAlerts bool `soql:"equalsOperator,fieldName=Disable_Alerts__c"`
+	EnableLogging *bool `soql:"equalsOperator,fieldName=Enable_Logging__c"`
 }
 
 type QueryCriteriaWithDateTimeType struct {


### PR DESCRIPTION
This change is needed in order to avoid init of empty boolean members of the struct to false by default. Similar functionality is already implemented in buildNullClause.