### PR TITLE
#4 Limit and offset

### DIFF
--- a/marshaller.go
+++ b/marshaller.go
@@ -136,6 +136,9 @@ var (
 
 	// ErrInvalidOffsetClause error is returned when field with offsetClause tag is invalid
 	ErrInvalidOffsetClause = errors.New("ErrInvalidOffsetClause")
+
+	// ErrMultipleOffsetClause error is returned when there are multiple offsetClause in struct
+	ErrMultipleOffsetClause = errors.New("ErrMultipleOffsetClause")
 )
 
 // Order is the struct for defining the order by clause on a per column basis
@@ -803,6 +806,9 @@ func marshal(reflectedValue reflect.Value, reflectedType reflect.Type, childRela
 				limitValue = reflectedValue.Field(i).Interface()
 				limitClausePresent = true
 			case OffsetClause:
+				if offsetClausePresent {
+					return "", ErrMultipleOffsetClause
+				}
 				offsetValue = reflectedValue.Field(i).Interface()
 				offsetClausePresent = true
 			default:

--- a/marshaller.go
+++ b/marshaller.go
@@ -457,18 +457,21 @@ func marshalOffsetClause(v interface{}) (string, error) {
 }
 
 func marshalIntValue(v interface{}) (string, error) {
-	vInt, ok := v.(int)
+	vPtr, ok := v.(*int)
 	if !ok {
 		return "", errors.New("invalid type")
 	}
+	if vPtr == nil {
+		return "", nil
+	}
+
+	vInt := *vPtr
 	if vInt < 0 {
 		return "", errors.New("invalid value")
 	}
 
-	var vString string
-	if vInt > 0 {
-		vString = strconv.Itoa(vInt)
-	}
+	vString := strconv.Itoa(vInt)
+
 	return vString, nil
 }
 

--- a/marshaller.go
+++ b/marshaller.go
@@ -457,17 +457,17 @@ func marshalOffsetClause(v interface{}) (string, error) {
 }
 
 func marshalIntValue(v interface{}) (string, error) {
-	limit, ok := v.(int)
+	vInt, ok := v.(int)
 	if !ok {
 		return "", errors.New("invalid type")
 	}
-	if limit < 0 {
+	if vInt < 0 {
 		return "", errors.New("invalid value")
 	}
 
 	var vString string
-	if limit > 0 {
-		vString = strconv.Itoa(limit)
+	if vInt > 0 {
+		vString = strconv.Itoa(vInt)
 	}
 	return vString, nil
 }

--- a/marshaller.go
+++ b/marshaller.go
@@ -63,9 +63,9 @@ const (
 	WhereClause = "whereClause"
 	// OrderByClause is the tag to be used when marking the string slice to be considered for order by clause
 	OrderByClause = "orderByClause"
-	// LimitClause is the tag to be used when marking the string slice to be considered for limit clause
+	// LimitClause is the tag to be used when marking the int to be considered for limit clause
 	LimitClause = "limitClause"
-	// OffsetClause is the tag to be used when marking the string slice to be considered for offset clause
+	// OffsetClause is the tag to be used when marking the int to be considered for offset clause
 	OffsetClause = "offsetClause"
 	// LikeOperator is the tag to be used for "like" operator in where clause
 	LikeOperator = "likeOperator"

--- a/marshaller_test.go
+++ b/marshaller_test.go
@@ -1107,7 +1107,7 @@ var _ = Describe("Marshaller", func() {
 			})
 		})
 
-		Context("when a struct with invalid limit value is passed", func() {
+		Context("when a struct with invalid limit type is passed", func() {
 			BeforeEach(func() {
 				soqlStruct = TestSoqlInvalidLimitStruct{
 					SelectClause: NestedStruct{},
@@ -1116,6 +1116,23 @@ var _ = Describe("Marshaller", func() {
 						Roles:              []string{"db", "dbmgmt"},
 					},
 					Limit: "5",
+				}
+			})
+
+			It("returns error", func() {
+				Expect(err).To(Equal(ErrInvalidLimitClause))
+			})
+		})
+
+		Context("when a struct with invalid limit value is passed", func() {
+			BeforeEach(func() {
+				soqlStruct = TestSoqlLimitStruct{
+					SelectClause: NestedStruct{},
+					WhereClause: TestQueryCriteria{
+						IncludeNamePattern: []string{"-db", "-dbmgmt"},
+						Roles:              []string{"db", "dbmgmt"},
+					},
+					Limit: -5,
 				}
 			})
 
@@ -1178,5 +1195,94 @@ var _ = Describe("Marshaller", func() {
 				Expect(actualQuery).To(Equal(expectedQuery))
 			})
 		})
+
+		Context("when a struct with offset value is passed", func() {
+			BeforeEach(func() {
+				soqlStruct = TestSoqlOffsetStruct{
+					SelectClause: NestedStruct{},
+					WhereClause: TestQueryCriteria{
+						IncludeNamePattern: []string{"-db", "-dbmgmt"},
+						Roles:              []string{"db", "dbmgmt"},
+					},
+					Offset: 5,
+				}
+				expectedQuery = "SELECT Id,Name__c,NonNestedStruct__r.Name,NonNestedStruct__r.SomeValue__c FROM SM_Logical_Host__c WHERE (Host_Name__c LIKE '%-db%' OR Host_Name__c LIKE '%-dbmgmt%') AND Role__r.Name IN ('db','dbmgmt') OFFSET 5"
+			})
+
+			It("returns properly constructed soql query", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(actualQuery).To(Equal(expectedQuery))
+			})
+		})
+
+		Context("when a struct without offset value is passed", func() {
+			BeforeEach(func() {
+				soqlStruct = TestSoqlOffsetStruct{
+					SelectClause: NestedStruct{},
+					WhereClause: TestQueryCriteria{
+						IncludeNamePattern: []string{"-db", "-dbmgmt"},
+						Roles:              []string{"db", "dbmgmt"},
+					},
+				}
+				expectedQuery = "SELECT Id,Name__c,NonNestedStruct__r.Name,NonNestedStruct__r.SomeValue__c FROM SM_Logical_Host__c WHERE (Host_Name__c LIKE '%-db%' OR Host_Name__c LIKE '%-dbmgmt%') AND Role__r.Name IN ('db','dbmgmt')"
+			})
+
+			It("returns properly constructed soql query", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(actualQuery).To(Equal(expectedQuery))
+			})
+		})
+
+		Context("when a struct with invalid offset type is passed", func() {
+			BeforeEach(func() {
+				soqlStruct = TestSoqlInvalidOffsetStruct{
+					SelectClause: NestedStruct{},
+					WhereClause: TestQueryCriteria{
+						IncludeNamePattern: []string{"-db", "-dbmgmt"},
+						Roles:              []string{"db", "dbmgmt"},
+					},
+					Offset: "5",
+				}
+			})
+
+			It("returns error", func() {
+				Expect(err).To(Equal(ErrInvalidOffsetClause))
+			})
+		})
+
+		// Context("when a struct with invalid limit value is passed", func() {
+		// 	BeforeEach(func() {
+		// 		soqlStruct = TestSoqlLimitStruct{
+		// 			SelectClause: NestedStruct{},
+		// 			WhereClause: TestQueryCriteria{
+		// 				IncludeNamePattern: []string{"-db", "-dbmgmt"},
+		// 				Roles:              []string{"db", "dbmgmt"},
+		// 			},
+		// 			Limit: -5,
+		// 		}
+		// 	})
+
+		// 	It("returns error", func() {
+		// 		Expect(err).To(Equal(ErrInvalidLimitClause))
+		// 	})
+		// })
+
+		// Context("when a struct with multiple limit values is passed", func() {
+		// 	BeforeEach(func() {
+		// 		soqlStruct = TestSoqlMultipleLimitStruct{
+		// 			SelectClause: NestedStruct{},
+		// 			WhereClause: TestQueryCriteria{
+		// 				IncludeNamePattern: []string{"-db", "-dbmgmt"},
+		// 				Roles:              []string{"db", "dbmgmt"},
+		// 			},
+		// 			Limit:     5,
+		// 			AlsoLimit: 15,
+		// 		}
+		// 	})
+
+		// 	It("returns error", func() {
+		// 		Expect(err).To(Equal(ErrMultipleLimitClause))
+		// 	})
+		// })
 	})
 })

--- a/marshaller_test.go
+++ b/marshaller_test.go
@@ -1072,13 +1072,14 @@ var _ = Describe("Marshaller", func() {
 
 		Context("when a struct with limit value greater than 0 is passed", func() {
 			BeforeEach(func() {
+				input := 5
 				soqlStruct = TestSoqlLimitStruct{
 					SelectClause: NestedStruct{},
 					WhereClause: TestQueryCriteria{
 						IncludeNamePattern: []string{"-db", "-dbmgmt"},
 						Roles:              []string{"db", "dbmgmt"},
 					},
-					Limit: 5,
+					Limit: &input,
 				}
 				expectedQuery = "SELECT Id,Name__c,NonNestedStruct__r.Name,NonNestedStruct__r.SomeValue__c FROM SM_Logical_Host__c WHERE (Host_Name__c LIKE '%-db%' OR Host_Name__c LIKE '%-dbmgmt%') AND Role__r.Name IN ('db','dbmgmt') LIMIT 5"
 			})
@@ -1091,15 +1092,16 @@ var _ = Describe("Marshaller", func() {
 
 		Context("when a struct with limit value equal to 0 is passed", func() {
 			BeforeEach(func() {
+				input := 0
 				soqlStruct = TestSoqlLimitStruct{
 					SelectClause: NestedStruct{},
 					WhereClause: TestQueryCriteria{
 						IncludeNamePattern: []string{"-db", "-dbmgmt"},
 						Roles:              []string{"db", "dbmgmt"},
 					},
-					Limit: 0,
+					Limit: &input,
 				}
-				expectedQuery = "SELECT Id,Name__c,NonNestedStruct__r.Name,NonNestedStruct__r.SomeValue__c FROM SM_Logical_Host__c WHERE (Host_Name__c LIKE '%-db%' OR Host_Name__c LIKE '%-dbmgmt%') AND Role__r.Name IN ('db','dbmgmt')"
+				expectedQuery = "SELECT Id,Name__c,NonNestedStruct__r.Name,NonNestedStruct__r.SomeValue__c FROM SM_Logical_Host__c WHERE (Host_Name__c LIKE '%-db%' OR Host_Name__c LIKE '%-dbmgmt%') AND Role__r.Name IN ('db','dbmgmt') LIMIT 0"
 			})
 
 			It("returns properly constructed soql query", func() {
@@ -1145,13 +1147,14 @@ var _ = Describe("Marshaller", func() {
 
 		Context("when a struct with invalid limit value is passed", func() {
 			BeforeEach(func() {
+				input := -5
 				soqlStruct = TestSoqlLimitStruct{
 					SelectClause: NestedStruct{},
 					WhereClause: TestQueryCriteria{
 						IncludeNamePattern: []string{"-db", "-dbmgmt"},
 						Roles:              []string{"db", "dbmgmt"},
 					},
-					Limit: -5,
+					Limit: &input,
 				}
 			})
 
@@ -1162,14 +1165,15 @@ var _ = Describe("Marshaller", func() {
 
 		Context("when a struct with multiple limit values is passed", func() {
 			BeforeEach(func() {
+				input := 5
 				soqlStruct = TestSoqlMultipleLimitStruct{
 					SelectClause: NestedStruct{},
 					WhereClause: TestQueryCriteria{
 						IncludeNamePattern: []string{"-db", "-dbmgmt"},
 						Roles:              []string{"db", "dbmgmt"},
 					},
-					Limit:     5,
-					AlsoLimit: 15,
+					Limit:     &input,
+					AlsoLimit: &input,
 				}
 			})
 
@@ -1180,10 +1184,11 @@ var _ = Describe("Marshaller", func() {
 
 		Context("when a struct with limit inside a child relation is passed", func() {
 			BeforeEach(func() {
+				input := 1
 				soqlStruct = TestSoqlChildRelationLimitStruct{
 					SelectClause: ParentLimitStruct{
 						ChildStruct: ChildLimitStruct{
-							Limit: 1,
+							Limit: &input,
 						},
 					},
 				}
@@ -1198,13 +1203,15 @@ var _ = Describe("Marshaller", func() {
 
 		Context("when a struct with limit inside a child relation is passed", func() {
 			BeforeEach(func() {
+				inputChild := 10
+				inputParent := 25
 				soqlStruct = TestSoqlChildRelationLimitStruct{
 					SelectClause: ParentLimitStruct{
 						ChildStruct: ChildLimitStruct{
-							Limit: 10,
+							Limit: &inputChild,
 						},
 					},
-					Limit: 25,
+					Limit: &inputParent,
 				}
 				expectedQuery = "SELECT Id,Name__c,(SELECT Application_Versions__c.Id,Application_Versions__c.Version__c FROM Application_Versions__r LIMIT 10) FROM SM_Logical_Host__c LIMIT 25"
 			})
@@ -1217,13 +1224,14 @@ var _ = Describe("Marshaller", func() {
 
 		Context("when a struct with offset value is passed", func() {
 			BeforeEach(func() {
+				input := 5
 				soqlStruct = TestSoqlOffsetStruct{
 					SelectClause: NestedStruct{},
 					WhereClause: TestQueryCriteria{
 						IncludeNamePattern: []string{"-db", "-dbmgmt"},
 						Roles:              []string{"db", "dbmgmt"},
 					},
-					Offset: 5,
+					Offset: &input,
 				}
 				expectedQuery = "SELECT Id,Name__c,NonNestedStruct__r.Name,NonNestedStruct__r.SomeValue__c FROM SM_Logical_Host__c WHERE (Host_Name__c LIKE '%-db%' OR Host_Name__c LIKE '%-dbmgmt%') AND Role__r.Name IN ('db','dbmgmt') OFFSET 5"
 			})
@@ -1254,15 +1262,16 @@ var _ = Describe("Marshaller", func() {
 
 		Context("when a struct with offset value of 0 is passed", func() {
 			BeforeEach(func() {
+				input := 0
 				soqlStruct = TestSoqlOffsetStruct{
 					SelectClause: NestedStruct{},
 					WhereClause: TestQueryCriteria{
 						IncludeNamePattern: []string{"-db", "-dbmgmt"},
 						Roles:              []string{"db", "dbmgmt"},
 					},
-					Offset: 0,
+					Offset: &input,
 				}
-				expectedQuery = "SELECT Id,Name__c,NonNestedStruct__r.Name,NonNestedStruct__r.SomeValue__c FROM SM_Logical_Host__c WHERE (Host_Name__c LIKE '%-db%' OR Host_Name__c LIKE '%-dbmgmt%') AND Role__r.Name IN ('db','dbmgmt')"
+				expectedQuery = "SELECT Id,Name__c,NonNestedStruct__r.Name,NonNestedStruct__r.SomeValue__c FROM SM_Logical_Host__c WHERE (Host_Name__c LIKE '%-db%' OR Host_Name__c LIKE '%-dbmgmt%') AND Role__r.Name IN ('db','dbmgmt') OFFSET 0"
 			})
 
 			It("returns properly constructed soql query", func() {
@@ -1290,13 +1299,14 @@ var _ = Describe("Marshaller", func() {
 
 		Context("when a struct with invalid offset value is passed", func() {
 			BeforeEach(func() {
+				input := -5
 				soqlStruct = TestSoqlOffsetStruct{
 					SelectClause: NestedStruct{},
 					WhereClause: TestQueryCriteria{
 						IncludeNamePattern: []string{"-db", "-dbmgmt"},
 						Roles:              []string{"db", "dbmgmt"},
 					},
-					Offset: -5,
+					Offset: &input,
 				}
 			})
 
@@ -1307,14 +1317,15 @@ var _ = Describe("Marshaller", func() {
 
 		Context("when a struct with multiple offset values is passed", func() {
 			BeforeEach(func() {
+				input := 5
 				soqlStruct = TestSoqlMultipleOffsetStruct{
 					SelectClause: NestedStruct{},
 					WhereClause: TestQueryCriteria{
 						IncludeNamePattern: []string{"-db", "-dbmgmt"},
 						Roles:              []string{"db", "dbmgmt"},
 					},
-					Offset:     5,
-					AlsoOffset: 15,
+					Offset:     &input,
+					AlsoOffset: &input,
 				}
 			})
 
@@ -1325,14 +1336,16 @@ var _ = Describe("Marshaller", func() {
 
 		Context("when a struct with offset value and limit value is passed", func() {
 			BeforeEach(func() {
+				inputLimit := 15
+				inputOffset := 5
 				soqlStruct = TestSoqlLimitAndOffsetStruct{
 					SelectClause: NestedStruct{},
 					WhereClause: TestQueryCriteria{
 						IncludeNamePattern: []string{"-db", "-dbmgmt"},
 						Roles:              []string{"db", "dbmgmt"},
 					},
-					Limit:  15,
-					Offset: 5,
+					Limit:  &inputLimit,
+					Offset: &inputOffset,
 				}
 				expectedQuery = "SELECT Id,Name__c,NonNestedStruct__r.Name,NonNestedStruct__r.SomeValue__c FROM SM_Logical_Host__c WHERE (Host_Name__c LIKE '%-db%' OR Host_Name__c LIKE '%-dbmgmt%') AND Role__r.Name IN ('db','dbmgmt') LIMIT 15 OFFSET 5"
 			})

--- a/marshaller_test.go
+++ b/marshaller_test.go
@@ -1250,39 +1250,39 @@ var _ = Describe("Marshaller", func() {
 			})
 		})
 
-		// Context("when a struct with invalid limit value is passed", func() {
-		// 	BeforeEach(func() {
-		// 		soqlStruct = TestSoqlLimitStruct{
-		// 			SelectClause: NestedStruct{},
-		// 			WhereClause: TestQueryCriteria{
-		// 				IncludeNamePattern: []string{"-db", "-dbmgmt"},
-		// 				Roles:              []string{"db", "dbmgmt"},
-		// 			},
-		// 			Limit: -5,
-		// 		}
-		// 	})
+		Context("when a struct with invalid offset value is passed", func() {
+			BeforeEach(func() {
+				soqlStruct = TestSoqlOffsetStruct{
+					SelectClause: NestedStruct{},
+					WhereClause: TestQueryCriteria{
+						IncludeNamePattern: []string{"-db", "-dbmgmt"},
+						Roles:              []string{"db", "dbmgmt"},
+					},
+					Offset: -5,
+				}
+			})
 
-		// 	It("returns error", func() {
-		// 		Expect(err).To(Equal(ErrInvalidLimitClause))
-		// 	})
-		// })
+			It("returns error", func() {
+				Expect(err).To(Equal(ErrInvalidOffsetClause))
+			})
+		})
 
-		// Context("when a struct with multiple limit values is passed", func() {
-		// 	BeforeEach(func() {
-		// 		soqlStruct = TestSoqlMultipleLimitStruct{
-		// 			SelectClause: NestedStruct{},
-		// 			WhereClause: TestQueryCriteria{
-		// 				IncludeNamePattern: []string{"-db", "-dbmgmt"},
-		// 				Roles:              []string{"db", "dbmgmt"},
-		// 			},
-		// 			Limit:     5,
-		// 			AlsoLimit: 15,
-		// 		}
-		// 	})
+		Context("when a struct with multiple offset values is passed", func() {
+			BeforeEach(func() {
+				soqlStruct = TestSoqlMultipleOffsetStruct{
+					SelectClause: NestedStruct{},
+					WhereClause: TestQueryCriteria{
+						IncludeNamePattern: []string{"-db", "-dbmgmt"},
+						Roles:              []string{"db", "dbmgmt"},
+					},
+					Offset:     5,
+					AlsoOffset: 15,
+				}
+			})
 
-		// 	It("returns error", func() {
-		// 		Expect(err).To(Equal(ErrMultipleLimitClause))
-		// 	})
-		// })
+			It("returns error", func() {
+				Expect(err).To(Equal(ErrMultipleOffsetClause))
+			})
+		})
 	})
 })

--- a/marshaller_test.go
+++ b/marshaller_test.go
@@ -1070,7 +1070,7 @@ var _ = Describe("Marshaller", func() {
 			})
 		})
 
-		Context("when a struct with limit value is passed", func() {
+		Context("when a struct with limit value greater than 0 is passed", func() {
 			BeforeEach(func() {
 				soqlStruct = TestSoqlLimitStruct{
 					SelectClause: NestedStruct{},
@@ -1081,6 +1081,25 @@ var _ = Describe("Marshaller", func() {
 					Limit: 5,
 				}
 				expectedQuery = "SELECT Id,Name__c,NonNestedStruct__r.Name,NonNestedStruct__r.SomeValue__c FROM SM_Logical_Host__c WHERE (Host_Name__c LIKE '%-db%' OR Host_Name__c LIKE '%-dbmgmt%') AND Role__r.Name IN ('db','dbmgmt') LIMIT 5"
+			})
+
+			It("returns properly constructed soql query", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(actualQuery).To(Equal(expectedQuery))
+			})
+		})
+
+		Context("when a struct with limit value equal to 0 is passed", func() {
+			BeforeEach(func() {
+				soqlStruct = TestSoqlLimitStruct{
+					SelectClause: NestedStruct{},
+					WhereClause: TestQueryCriteria{
+						IncludeNamePattern: []string{"-db", "-dbmgmt"},
+						Roles:              []string{"db", "dbmgmt"},
+					},
+					Limit: 0,
+				}
+				expectedQuery = "SELECT Id,Name__c,NonNestedStruct__r.Name,NonNestedStruct__r.SomeValue__c FROM SM_Logical_Host__c WHERE (Host_Name__c LIKE '%-db%' OR Host_Name__c LIKE '%-dbmgmt%') AND Role__r.Name IN ('db','dbmgmt')"
 			})
 
 			It("returns properly constructed soql query", func() {
@@ -1233,6 +1252,25 @@ var _ = Describe("Marshaller", func() {
 			})
 		})
 
+		Context("when a struct with offset value of 0 is passed", func() {
+			BeforeEach(func() {
+				soqlStruct = TestSoqlOffsetStruct{
+					SelectClause: NestedStruct{},
+					WhereClause: TestQueryCriteria{
+						IncludeNamePattern: []string{"-db", "-dbmgmt"},
+						Roles:              []string{"db", "dbmgmt"},
+					},
+					Offset: 0,
+				}
+				expectedQuery = "SELECT Id,Name__c,NonNestedStruct__r.Name,NonNestedStruct__r.SomeValue__c FROM SM_Logical_Host__c WHERE (Host_Name__c LIKE '%-db%' OR Host_Name__c LIKE '%-dbmgmt%') AND Role__r.Name IN ('db','dbmgmt')"
+			})
+
+			It("returns properly constructed soql query", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(actualQuery).To(Equal(expectedQuery))
+			})
+		})
+
 		Context("when a struct with invalid offset type is passed", func() {
 			BeforeEach(func() {
 				soqlStruct = TestSoqlInvalidOffsetStruct{
@@ -1282,6 +1320,26 @@ var _ = Describe("Marshaller", func() {
 
 			It("returns error", func() {
 				Expect(err).To(Equal(ErrMultipleOffsetClause))
+			})
+		})
+
+		Context("when a struct with offset value and limit value is passed", func() {
+			BeforeEach(func() {
+				soqlStruct = TestSoqlLimitAndOffsetStruct{
+					SelectClause: NestedStruct{},
+					WhereClause: TestQueryCriteria{
+						IncludeNamePattern: []string{"-db", "-dbmgmt"},
+						Roles:              []string{"db", "dbmgmt"},
+					},
+					Limit:  15,
+					Offset: 5,
+				}
+				expectedQuery = "SELECT Id,Name__c,NonNestedStruct__r.Name,NonNestedStruct__r.SomeValue__c FROM SM_Logical_Host__c WHERE (Host_Name__c LIKE '%-db%' OR Host_Name__c LIKE '%-dbmgmt%') AND Role__r.Name IN ('db','dbmgmt') LIMIT 15 OFFSET 5"
+			})
+
+			It("returns properly constructed soql query", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(actualQuery).To(Equal(expectedQuery))
 			})
 		})
 	})

--- a/soql_suite_test.go
+++ b/soql_suite_test.go
@@ -229,3 +229,43 @@ type TestSoqlChildRelationOrderByStruct struct {
 	SelectClause  OrderByParentStruct `soql:"selectClause,tableName=SM_Logical_Host__c"`
 	OrderByClause []Order             `soql:"orderByClause"`
 }
+
+type TestSoqlLimitStruct struct {
+	SelectClause NestedStruct      `soql:"selectClause,tableName=SM_Logical_Host__c"`
+	WhereClause  TestQueryCriteria `soql:"whereClause"`
+	Limit        int               `soql:"limitClause"`
+}
+
+type TestSoqlInvalidLimitStruct struct {
+	SelectClause NestedStruct      `soql:"selectClause,tableName=SM_Logical_Host__c"`
+	WhereClause  TestQueryCriteria `soql:"whereClause"`
+	Limit        string            `soql:"limitClause"`
+}
+
+type TestSoqlMultipleLimitStruct struct {
+	SelectClause NestedStruct      `soql:"selectClause,tableName=SM_Logical_Host__c"`
+	WhereClause  TestQueryCriteria `soql:"whereClause"`
+	Limit        int               `soql:"limitClause"`
+	AlsoLimit    int               `soql:"limitClause"`
+}
+
+type ParentLimitStruct struct {
+	ID          string           `soql:"selectColumn,fieldName=Id"`
+	Name        string           `soql:"selectColumn,fieldName=Name__c"`
+	ChildStruct ChildLimitStruct `soql:"selectChild,fieldName=Application_Versions__r"`
+}
+
+type ChildLimitStruct struct {
+	SelectClause TestChildLimitSelect `soql:"selectClause,tableName=Application_Versions__c"`
+	Limit        int                  `soql:"limitClause"`
+}
+
+type TestChildLimitSelect struct {
+	ID      string `soql:"selectColumn,fieldName=Id"`
+	Version string `soql:"selectColumn,fieldName=Version__c"`
+}
+
+type TestSoqlChildRelationLimitStruct struct {
+	SelectClause ParentLimitStruct `soql:"selectClause,tableName=SM_Logical_Host__c"`
+	Limit        int               `soql:"limitClause"`
+}

--- a/soql_suite_test.go
+++ b/soql_suite_test.go
@@ -281,3 +281,10 @@ type TestSoqlInvalidOffsetStruct struct {
 	WhereClause  TestQueryCriteria `soql:"whereClause"`
 	Offset       string            `soql:"offsetClause"`
 }
+
+type TestSoqlMultipleOffsetStruct struct {
+	SelectClause NestedStruct      `soql:"selectClause,tableName=SM_Logical_Host__c"`
+	WhereClause  TestQueryCriteria `soql:"whereClause"`
+	Offset       int               `soql:"offsetClause"`
+	AlsoOffset   int               `soql:"offsetClause"`
+}

--- a/soql_suite_test.go
+++ b/soql_suite_test.go
@@ -269,3 +269,15 @@ type TestSoqlChildRelationLimitStruct struct {
 	SelectClause ParentLimitStruct `soql:"selectClause,tableName=SM_Logical_Host__c"`
 	Limit        int               `soql:"limitClause"`
 }
+
+type TestSoqlOffsetStruct struct {
+	SelectClause NestedStruct      `soql:"selectClause,tableName=SM_Logical_Host__c"`
+	WhereClause  TestQueryCriteria `soql:"whereClause"`
+	Offset       int               `soql:"offsetClause"`
+}
+
+type TestSoqlInvalidOffsetStruct struct {
+	SelectClause NestedStruct      `soql:"selectClause,tableName=SM_Logical_Host__c"`
+	WhereClause  TestQueryCriteria `soql:"whereClause"`
+	Offset       string            `soql:"offsetClause"`
+}

--- a/soql_suite_test.go
+++ b/soql_suite_test.go
@@ -288,3 +288,10 @@ type TestSoqlMultipleOffsetStruct struct {
 	Offset       int               `soql:"offsetClause"`
 	AlsoOffset   int               `soql:"offsetClause"`
 }
+
+type TestSoqlLimitAndOffsetStruct struct {
+	SelectClause NestedStruct      `soql:"selectClause,tableName=SM_Logical_Host__c"`
+	WhereClause  TestQueryCriteria `soql:"whereClause"`
+	Limit        int               `soql:"limitClause"`
+	Offset       int               `soql:"offsetClause"`
+}

--- a/soql_suite_test.go
+++ b/soql_suite_test.go
@@ -233,7 +233,7 @@ type TestSoqlChildRelationOrderByStruct struct {
 type TestSoqlLimitStruct struct {
 	SelectClause NestedStruct      `soql:"selectClause,tableName=SM_Logical_Host__c"`
 	WhereClause  TestQueryCriteria `soql:"whereClause"`
-	Limit        int               `soql:"limitClause"`
+	Limit        *int              `soql:"limitClause"`
 }
 
 type TestSoqlInvalidLimitStruct struct {
@@ -245,8 +245,8 @@ type TestSoqlInvalidLimitStruct struct {
 type TestSoqlMultipleLimitStruct struct {
 	SelectClause NestedStruct      `soql:"selectClause,tableName=SM_Logical_Host__c"`
 	WhereClause  TestQueryCriteria `soql:"whereClause"`
-	Limit        int               `soql:"limitClause"`
-	AlsoLimit    int               `soql:"limitClause"`
+	Limit        *int              `soql:"limitClause"`
+	AlsoLimit    *int              `soql:"limitClause"`
 }
 
 type ParentLimitStruct struct {
@@ -257,7 +257,7 @@ type ParentLimitStruct struct {
 
 type ChildLimitStruct struct {
 	SelectClause TestChildLimitSelect `soql:"selectClause,tableName=Application_Versions__c"`
-	Limit        int                  `soql:"limitClause"`
+	Limit        *int                 `soql:"limitClause"`
 }
 
 type TestChildLimitSelect struct {
@@ -267,13 +267,13 @@ type TestChildLimitSelect struct {
 
 type TestSoqlChildRelationLimitStruct struct {
 	SelectClause ParentLimitStruct `soql:"selectClause,tableName=SM_Logical_Host__c"`
-	Limit        int               `soql:"limitClause"`
+	Limit        *int              `soql:"limitClause"`
 }
 
 type TestSoqlOffsetStruct struct {
 	SelectClause NestedStruct      `soql:"selectClause,tableName=SM_Logical_Host__c"`
 	WhereClause  TestQueryCriteria `soql:"whereClause"`
-	Offset       int               `soql:"offsetClause"`
+	Offset       *int              `soql:"offsetClause"`
 }
 
 type TestSoqlInvalidOffsetStruct struct {
@@ -285,13 +285,13 @@ type TestSoqlInvalidOffsetStruct struct {
 type TestSoqlMultipleOffsetStruct struct {
 	SelectClause NestedStruct      `soql:"selectClause,tableName=SM_Logical_Host__c"`
 	WhereClause  TestQueryCriteria `soql:"whereClause"`
-	Offset       int               `soql:"offsetClause"`
-	AlsoOffset   int               `soql:"offsetClause"`
+	Offset       *int              `soql:"offsetClause"`
+	AlsoOffset   *int              `soql:"offsetClause"`
 }
 
 type TestSoqlLimitAndOffsetStruct struct {
 	SelectClause NestedStruct      `soql:"selectClause,tableName=SM_Logical_Host__c"`
 	WhereClause  TestQueryCriteria `soql:"whereClause"`
-	Limit        int               `soql:"limitClause"`
-	Offset       int               `soql:"offsetClause"`
+	Limit        *int              `soql:"limitClause"`
+	Offset       *int              `soql:"offsetClause"`
 }


### PR DESCRIPTION
Added support for limit and offset with tests.  I considered making offset on a child query an error since I don't believe Salesforce supports that behavior, but changed my mind so that select structs could be used as parents or children.