### PR TITLE
Allowing pointers with "subquery" tag

### DIFF
--- a/marshaller.go
+++ b/marshaller.go
@@ -532,7 +532,7 @@ func marshalWhereClause(v interface{}, tableName, joiner string) (string, error)
 		clauseKey := getClauseKey(clauseTag)
 		var partialClause string
 		if clauseKey == Subquery {
-			if field.Kind() != reflect.Struct {
+			if field.Kind() != reflect.Struct && field.Kind() != reflect.Ptr {
 				return "", ErrInvalidTag
 			}
 			joiner, err := getJoiner(clauseTag)


### PR DESCRIPTION
Allowing pointers with "subquery" tag in order to support optional subqueries in WhereClause. It will make behavior consistent with other conditions as they are allowed to be null. 