### PR TITLE
Allowing pointers with "subquery" tag (revised)

### DIFF
--- a/marshaller.go
+++ b/marshaller.go
@@ -532,7 +532,7 @@ func marshalWhereClause(v interface{}, tableName, joiner string) (string, error)
 		clauseKey := getClauseKey(clauseTag)
 		var partialClause string
 		if clauseKey == Subquery {
-			if field.Kind() != reflect.Struct {
+			if field.Kind() != reflect.Struct && field.Kind() != reflect.Ptr {
 				return "", ErrInvalidTag
 			}
 			joiner, err := getJoiner(clauseTag)

--- a/marshaller.go
+++ b/marshaller.go
@@ -535,6 +535,9 @@ func marshalWhereClause(v interface{}, tableName, joiner string) (string, error)
 			if field.Kind() != reflect.Struct && field.Kind() != reflect.Ptr {
 				return "", ErrInvalidTag
 			}
+			if field.Kind() == reflect.Ptr && reflect.ValueOf(field.Interface()).IsNil() {
+				continue
+			}
 			joiner, err := getJoiner(clauseTag)
 			if err != nil {
 				return "", err

--- a/marshaller.go
+++ b/marshaller.go
@@ -535,8 +535,10 @@ func marshalWhereClause(v interface{}, tableName, joiner string) (string, error)
 			if field.Kind() != reflect.Struct && field.Kind() != reflect.Ptr {
 				return "", ErrInvalidTag
 			}
-			if field.Kind() == reflect.Ptr && reflect.ValueOf(field.Interface()).IsNil() {
-				continue
+			if field.Kind() == reflect.Ptr {
+				if reflect.ValueOf(field.Interface()).IsNil() {
+					continue
+				}
 			}
 			joiner, err := getJoiner(clauseTag)
 			if err != nil {

--- a/marshaller_test.go
+++ b/marshaller_test.go
@@ -1583,6 +1583,31 @@ var _ = Describe("Marshaller", func() {
 			})
 		})
 
+		Context("when a struct with null pointer subquery passed in", func() {
+			BeforeEach(func() {
+				soqlStruct = soqlSubQueryPtrTestStruct{
+					WhereClause: ptrSubqueryCriteria{
+						Contactable: &contactableCriteria{
+							EmailOK: emailCheck{
+								Email:         false,
+								EmailOptedOut: false,
+							},
+							PhoneOK: phoneCheck{
+								Phone:     false,
+								DoNotCall: false,
+							},
+						},
+					},
+				}
+				expectedQuery = "SELECT Name,Email,Phone FROM Contact WHERE ((Email != null AND HasOptedOutOfEmail = false) OR (Phone != null AND DoNotCall = false))"
+			})
+
+			It("returns properly constructed soql query", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(actualQuery).To(Equal(expectedQuery))
+			})
+		})
+
 		Context("when a struct with where clause with subfilters passed in", func() {
 			BeforeEach(func() {
 				soqlStruct = soqlSubQueryTestStruct{

--- a/soql_suite_test.go
+++ b/soql_suite_test.go
@@ -390,3 +390,13 @@ type invalidSubqueryCriteria struct {
 	Position    string              `soql:"subquery,joiner=OR"`
 	Contactable contactableCriteria `soql:"subquery,joiner=OR"`
 }
+
+type soqlSubQueryPtrTestStruct struct {
+	SelectClause contact             `soql:"selectClause,tableName=Contact"`
+	WhereClause  ptrSubqueryCriteria `soql:"whereClause"`
+}
+
+type ptrSubqueryCriteria struct {
+	Position    *positionCriteria     `soql:"subquery,joiner=OR"`
+	Contactable *contactableCriteria `soql:"subquery,joiner=OR"`
+}


### PR DESCRIPTION
Allowing pointers with "subquery" tag in order to support optional subqueries in WhereClause. It will make behavior consistent with other conditions as they are allowed to be null.