### PR TITLE
fix #26 Escape special characters 

### DIFF
--- a/marshaller.go
+++ b/marshaller.go
@@ -144,7 +144,7 @@ var clauseBuilderMap = map[string]func(v interface{}, fieldName string) (string,
 	LessThanOrEqualsToOperator:    buildLessThanOrEqualsToClause,
 	GreaterNextNDaysOperator:      buildGreaterNextNDaysOperator,
 	EqualsNextNDaysOperator:       buildEqualsNextNDaysOperator,
-	LessNextNDaysOperator: 		   buildLessNextNDaysOperator,
+	LessNextNDaysOperator:         buildLessNextNDaysOperator,
 	GreaterLastNDaysOperator:      buildGreaterLastNDaysOperator,
 	EqualsLastNDaysOperator:       buildEqualsLastNDaysOperator,
 	LessLastNDaysOperator:         buildLessLastNDaysOperator,
@@ -371,27 +371,27 @@ func constructComparisonClause(v interface{}, fieldName, operator string) (strin
 	return buff.String(), nil
 }
 
-func buildGreaterNextNDaysOperator (v interface{}, fieldName string) (string, error) {
+func buildGreaterNextNDaysOperator(v interface{}, fieldName string) (string, error) {
 	return constructDateLiteralsClause(v, fieldName, greaterNextNDaysOperator)
 }
 
-func buildEqualsNextNDaysOperator (v interface{}, fieldName string) (string, error) {
+func buildEqualsNextNDaysOperator(v interface{}, fieldName string) (string, error) {
 	return constructDateLiteralsClause(v, fieldName, equalsNextNDaysOperator)
 }
 
-func buildLessNextNDaysOperator (v interface{}, fieldName string) (string, error) {
+func buildLessNextNDaysOperator(v interface{}, fieldName string) (string, error) {
 	return constructDateLiteralsClause(v, fieldName, lessNextNDaysOperator)
 }
 
-func buildGreaterLastNDaysOperator (v interface{}, fieldName string) (string, error) {
+func buildGreaterLastNDaysOperator(v interface{}, fieldName string) (string, error) {
 	return constructDateLiteralsClause(v, fieldName, greaterLastNDaysOperator)
 }
 
-func buildEqualsLastNDaysOperator (v interface{}, fieldName string) (string, error) {
+func buildEqualsLastNDaysOperator(v interface{}, fieldName string) (string, error) {
 	return constructDateLiteralsClause(v, fieldName, equalsLastNDaysOperator)
 }
 
-func buildLessLastNDaysOperator (v interface{}, fieldName string) (string, error) {
+func buildLessLastNDaysOperator(v interface{}, fieldName string) (string, error) {
 	return constructDateLiteralsClause(v, fieldName, lessLastNDaysOperator)
 }
 
@@ -399,7 +399,7 @@ func constructDateLiteralsClause(v interface{}, fieldName string, operator strin
 	var buff strings.Builder
 	var value string
 
-	switch u := v.(type){
+	switch u := v.(type) {
 	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
 		value = fmt.Sprint(u)
 	case *int, *int8, *int16, *int32, *int64, *uint, *uint8, *uint16, *uint32, *uint64:
@@ -417,7 +417,6 @@ func constructDateLiteralsClause(v interface{}, fieldName string, operator strin
 	}
 	return buff.String(), nil
 }
-
 
 func buildNullClause(v interface{}, fieldName string) (string, error) {
 	reflectedValue, _, err := getReflectedValueAndType(v)

--- a/marshaller_test.go
+++ b/marshaller_test.go
@@ -78,6 +78,20 @@ var _ = Describe("Marshaller", func() {
 						Expect(clause).To(Equal(expectedClause))
 					})
 				})
+
+				Context("when there are special characters in values", func() {
+					BeforeEach(func() {
+						critetria = TestQueryCriteria{
+							IncludeNamePattern: []string{"-db'_%\\"},
+							AssetType:          "-db'_%\\",
+						}
+						expectedClause = `Host_Name__c LIKE '%-db\'\_\%\\%' AND Tech_Asset__r.Asset_Type_Asset_Type__c = '-db\'_%\\'`
+					})
+
+					It("returns appropriate where clause by escaping special characters", func() {
+						Expect(clause).To(Equal(expectedClause))
+					})
+				})
 			})
 
 			Context("when only not like clause is populated", func() {

--- a/marshaller_test.go
+++ b/marshaller_test.go
@@ -368,33 +368,33 @@ var _ = Describe("Marshaller", func() {
 
 		Context("When values for date literals are int", func() {
 			var criteria QueryCriteriaDateLiteralsOperatorsInt
-				BeforeEach(func() {
-					criteria = QueryCriteriaDateLiteralsOperatorsInt{
-						CreatedDate: 5,
-						ClosedDate: 10,
-					}
-					expectedClause = "CreatedDate > NEXT_N_DAYS:5 AND ClosedDate < NEXT_N_DAYS:10"
-				})
-				It("returns appropriate where clause", func() {
-					clause, err = MarshalWhereClause(criteria)
-					Expect(clause).To(Equal(expectedClause))
-				})
+			BeforeEach(func() {
+				criteria = QueryCriteriaDateLiteralsOperatorsInt{
+					CreatedDate: 5,
+					ClosedDate:  10,
+				}
+				expectedClause = "CreatedDate > NEXT_N_DAYS:5 AND ClosedDate < NEXT_N_DAYS:10"
 			})
+			It("returns appropriate where clause", func() {
+				clause, err = MarshalWhereClause(criteria)
+				Expect(clause).To(Equal(expectedClause))
+			})
+		})
 
 		Context("When values for date literals are uint", func() {
 			var criteria QueryCriteriaDateLiteralsOperatorsUint
-				BeforeEach(func() {
-					criteria = QueryCriteriaDateLiteralsOperatorsUint{
-						CreatedDate: 5,
-						ClosedDate: 10,
-					}
-					expectedClause = "CreatedDate > NEXT_N_DAYS:5 AND ClosedDate < NEXT_N_DAYS:10"
-				})
-				It("returns appropriate where clause", func() {
-					clause, err = MarshalWhereClause(criteria)
-					Expect(clause).To(Equal(expectedClause))
-				})
+			BeforeEach(func() {
+				criteria = QueryCriteriaDateLiteralsOperatorsUint{
+					CreatedDate: 5,
+					ClosedDate:  10,
+				}
+				expectedClause = "CreatedDate > NEXT_N_DAYS:5 AND ClosedDate < NEXT_N_DAYS:10"
 			})
+			It("returns appropriate where clause", func() {
+				clause, err = MarshalWhereClause(criteria)
+				Expect(clause).To(Equal(expectedClause))
+			})
+		})
 
 		Context("When values for date literals are wrong type", func() {
 			type QueryCriteriaDateLiteralsOperatorsWrong struct {
@@ -412,7 +412,7 @@ var _ = Describe("Marshaller", func() {
 			})
 		})
 
-		Context("When values for date literals are pointers", func(){
+		Context("When values for date literals are pointers", func() {
 			var criteria QueryCriteriaDateLiteralsOperatorsPtr
 			Context("When there is only greaterNextNDaysOperator operator", func() {
 				BeforeEach(func() {
@@ -460,8 +460,8 @@ var _ = Describe("Marshaller", func() {
 					v3 := 15
 					criteria = QueryCriteriaDateLiteralsOperatorsPtr{
 						CreatedDate: &v0,
-						OtherDate: &v3,
-						ClosedDate: &v1,
+						OtherDate:   &v3,
+						ClosedDate:  &v1,
 					}
 					expectedClause = "CreatedDate > NEXT_N_DAYS:5 AND OtherDate = NEXT_N_DAYS:15 AND ClosedDate < NEXT_N_DAYS:10"
 				})
@@ -486,51 +486,51 @@ var _ = Describe("Marshaller", func() {
 					clause, err = MarshalWhereClause(criteria)
 					Expect(clause).To(Equal(expectedClause))
 				})
-			Context("when there is only greaterLastNDaysOperator operator", func() {
-				BeforeEach(func() {
-					v0 := 5
-					criteria = QueryCriteriaDateLastNDaysLiteralsOperatorsPtr{
-						CreatedDate: &v0,
-					}
-					expectedClause = "CreatedDate > LAST_N_DAYS:5"
+				Context("when there is only greaterLastNDaysOperator operator", func() {
+					BeforeEach(func() {
+						v0 := 5
+						criteria = QueryCriteriaDateLastNDaysLiteralsOperatorsPtr{
+							CreatedDate: &v0,
+						}
+						expectedClause = "CreatedDate > LAST_N_DAYS:5"
+					})
+					It("returns appropriate where clause", func() {
+						clause, err = MarshalWhereClause(criteria)
+						Expect(clause).To(Equal(expectedClause))
+					})
 				})
-				It("returns appropriate where clause", func() {
-					clause, err = MarshalWhereClause(criteria)
-					Expect(clause).To(Equal(expectedClause))
+				Context("when there is only equalsLastNDaysOperator operator", func() {
+					BeforeEach(func() {
+						v0 := 5
+						criteria = QueryCriteriaDateLastNDaysLiteralsOperatorsPtr{
+							OtherDate: &v0,
+						}
+						expectedClause = "OtherDate = LAST_N_DAYS:5"
+					})
+					It("returns appropriate where clause", func() {
+						clause, err = MarshalWhereClause(criteria)
+						Expect(clause).To(Equal(expectedClause))
+					})
 				})
-			})
-			Context("when there is only equalsLastNDaysOperator operator", func() {
-				BeforeEach(func() {
-					v0 := 5
-					criteria = QueryCriteriaDateLastNDaysLiteralsOperatorsPtr{
-						OtherDate: &v0,
-					}
-					expectedClause = "OtherDate = LAST_N_DAYS:5"
-				})
-				It("returns appropriate where clause", func() {
-					clause, err = MarshalWhereClause(criteria)
-					Expect(clause).To(Equal(expectedClause))
-				})
-			})
-			Context("when there are greaterLastNDaysOperator, lessLastNDaysOperator and equalsLastNDaysOperator operators", func() {
-				BeforeEach(func() {
-					v0 := 5
-					v1 := 10
-					v3 := 15
-					criteria = QueryCriteriaDateLastNDaysLiteralsOperatorsPtr{
-						CreatedDate: &v0,
-						OtherDate: &v3,
-						ClosedDate:  &v1,
-					}
-					expectedClause = "CreatedDate > LAST_N_DAYS:5 AND OtherDate = LAST_N_DAYS:15 AND ClosedDate < LAST_N_DAYS:10"
-				})
-				It("returns appropriate where clause", func() {
-					clause, err = MarshalWhereClause(criteria)
-					Expect(clause).To(Equal(expectedClause))
+				Context("when there are greaterLastNDaysOperator, lessLastNDaysOperator and equalsLastNDaysOperator operators", func() {
+					BeforeEach(func() {
+						v0 := 5
+						v1 := 10
+						v3 := 15
+						criteria = QueryCriteriaDateLastNDaysLiteralsOperatorsPtr{
+							CreatedDate: &v0,
+							OtherDate:   &v3,
+							ClosedDate:  &v1,
+						}
+						expectedClause = "CreatedDate > LAST_N_DAYS:5 AND OtherDate = LAST_N_DAYS:15 AND ClosedDate < LAST_N_DAYS:10"
+					})
+					It("returns appropriate where clause", func() {
+						clause, err = MarshalWhereClause(criteria)
+						Expect(clause).To(Equal(expectedClause))
+					})
 				})
 			})
 		})
-	})
 
 		Context("when all clauses are signed integer data types", func() {
 			var criteria QueryCriteriaWithIntegerTypes
@@ -671,7 +671,7 @@ var _ = Describe("Marshaller", func() {
 			BeforeEach(func() {
 				currentTime = time.Now()
 				criteria = QueryCriteriaWithPtrDateTimeType{
-					CreatedDate: &currentTime,
+					CreatedDate:  &currentTime,
 					ResolvedDate: nil,
 				}
 
@@ -703,7 +703,7 @@ var _ = Describe("Marshaller", func() {
 					MajorOSVersion:                   "20",
 					NumOfSuccessivePuppetRunFailures: 0,
 					LastRestart:                      currentTime,
-					ClosedDate:						  5,
+					ClosedDate:                       5,
 					NumHardDrives:                    &numHardDrives,
 				}
 
@@ -1170,7 +1170,7 @@ var _ = Describe("Marshaller", func() {
 						AllocationLatency:                10.5,
 						MajorOSVersion:                   "20",
 						NumOfSuccessivePuppetRunFailures: 0,
-						ClosedDate: 					  5,
+						ClosedDate:                       5,
 						LastRestart:                      currentTime,
 					},
 				}

--- a/soql_suite_test.go
+++ b/soql_suite_test.go
@@ -219,24 +219,24 @@ type QueryCriteriaNumericComparisonOperators struct {
 
 type QueryCriteriaDateLiteralsOperatorsInt struct {
 	CreatedDate int `soql:"greaterNextNDaysOperator,fieldName=CreatedDate"`
-	ClosedDate 	int `soql:"lessNextNDaysOperator,fieldName=ClosedDate"`
+	ClosedDate  int `soql:"lessNextNDaysOperator,fieldName=ClosedDate"`
 }
 
 type QueryCriteriaDateLiteralsOperatorsUint struct {
 	CreatedDate uint `soql:"greaterNextNDaysOperator,fieldName=CreatedDate"`
-	ClosedDate 	uint `soql:"lessNextNDaysOperator,fieldName=ClosedDate"`
+	ClosedDate  uint `soql:"lessNextNDaysOperator,fieldName=ClosedDate"`
 }
 
 type QueryCriteriaDateLiteralsOperatorsPtr struct {
 	CreatedDate *int `soql:"greaterNextNDaysOperator,fieldName=CreatedDate"`
 	OtherDate   *int `soql:"equalsNextNDaysOperator,fieldName=OtherDate"`
-	ClosedDate 	*int `soql:"lessNextNDaysOperator,fieldName=ClosedDate"`
+	ClosedDate  *int `soql:"lessNextNDaysOperator,fieldName=ClosedDate"`
 }
 
 type QueryCriteriaDateLastNDaysLiteralsOperatorsPtr struct {
 	CreatedDate *int `soql:"greaterLastNDaysOperator,fieldName=CreatedDate"`
 	OtherDate   *int `soql:"equalsLastNDaysOperator,fieldName=OtherDate"`
-	ClosedDate 	*int `soql:"lessLastNDaysOperator,fieldName=ClosedDate"`
+	ClosedDate  *int `soql:"lessLastNDaysOperator,fieldName=ClosedDate"`
 }
 
 type QueryCriteriaWithMixedDataTypesAndOperators struct {
@@ -253,7 +253,7 @@ type QueryCriteriaWithMixedDataTypesAndOperators struct {
 	LastRestart                      time.Time `soql:"greaterThanOperator,fieldName=Last_Restart__c"`
 	Memory                           *float64  `soql:"equalsOperator,fieldName=Memory__c"`
 	NumHardDrives                    *int      `soql:"equalsOperator,fieldName=NumHardDrives__c"`
-	ClosedDate 					     int 	   `soql:"greaterNextNDaysOperator,fieldName=ClosedDate"`
+	ClosedDate                       int       `soql:"greaterNextNDaysOperator,fieldName=ClosedDate"`
 }
 
 type InvalidSelectClause struct {


### PR DESCRIPTION
ref. #26
I fixed to escape all special characters described in the document.
https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql_select_quotedstringescapes.htm