### PR TITLE
Making soql tag optional in WhereClause

### DIFF
--- a/marshaller.go
+++ b/marshaller.go
@@ -121,25 +121,25 @@ const (
 	LessThanOperator = "lessThanOperator"
 	// LessThanOrEqualsToOperator is the tag to be used for "<=" operator in where clause
 	LessThanOrEqualsToOperator = "lessThanOrEqualsToOperator"
-	//GreaterNextNDaysOperator is the tag to be used for "> NEXT_N_DAYS:n" operator in where clause
+	// GreaterNextNDaysOperator is the tag to be used for "> NEXT_N_DAYS:n" operator in where clause
 	GreaterNextNDaysOperator = "greaterNextNDaysOperator"
-	//GreaterNextNDaysOperator is the tag to be used for ">= NEXT_N_DAYS:n" operator in where clause
+	// GreaterOrEqualNextNDaysOperator is the tag to be used for ">= NEXT_N_DAYS:n" operator in where clause
 	GreaterOrEqualNextNDaysOperator = "greaterOrEqualNextNDaysOperator"
-	//EqualsNextNDaysOperator is the tag to be used for "= NEXT_N_DAYS:n" operator in where clause
+	// EqualsNextNDaysOperator is the tag to be used for "= NEXT_N_DAYS:n" operator in where clause
 	EqualsNextNDaysOperator = "equalsNextNDaysOperator"
-	//LessNextNDaysOperator is the tag to be used for "< NEXT_N_DAYS:n" operator in where clause
+	// LessNextNDaysOperator is the tag to be used for "< NEXT_N_DAYS:n" operator in where clause
 	LessNextNDaysOperator = "lessNextNDaysOperator"
-	//LessOrEqualNextNDaysOperator is the tag to be used for "<= NEXT_N_DAYS:n" operator in where clause
+	// LessOrEqualNextNDaysOperator is the tag to be used for "<= NEXT_N_DAYS:n" operator in where clause
 	LessOrEqualNextNDaysOperator = "lessOrEqualNextNDaysOperator"
-	//GreaterLastNDaysOperator is the tag to be used for "> LAST_N_DAYS:n" operator in where clause
+	// GreaterLastNDaysOperator is the tag to be used for "> LAST_N_DAYS:n" operator in where clause
 	GreaterLastNDaysOperator = "greaterLastNDaysOperator"
-	//GreaterOrEqualLastNDaysOperator is the tag to be used for ">= LAST_N_DAYS:n" operator in where clause
+	// GreaterOrEqualLastNDaysOperator is the tag to be used for ">= LAST_N_DAYS:n" operator in where clause
 	GreaterOrEqualLastNDaysOperator = "greaterOrEqualLastNDaysOperator"
-	//EqualsLastNDaysOperator is the tag to be used for "= LAST_N_DAYS:n" operator in where clause
+	// EqualsLastNDaysOperator is the tag to be used for "= LAST_N_DAYS:n" operator in where clause
 	EqualsLastNDaysOperator = "equalsLastNDaysOperator"
-	//LessLastNDaysOperator is the tag to be used for "< LAST_N_DAYS:n" operator in where clause
+	// LessLastNDaysOperator is the tag to be used for "< LAST_N_DAYS:n" operator in where clause
 	LessLastNDaysOperator = "lessLastNDaysOperator"
-	//LessOrEqualLastNDaysOperator is the tag to be used for "<= LAST_N_DAYS:n" operator in where clause
+	// LessOrEqualLastNDaysOperator is the tag to be used for "<= LAST_N_DAYS:n" operator in where clause
 	LessOrEqualLastNDaysOperator = "lessOrEqualLastNDaysOperator"
 
 	// Subquery is the tag to be used for a subquery in a where clause
@@ -685,6 +685,9 @@ func marshalWhereClause(v interface{}, tableName, joiner string) (string, error)
 		field := reflectedValue.Field(i)
 		fieldType := reflectedType.Field(i)
 		clauseTag := fieldType.Tag.Get(SoqlTag)
+		if clauseTag == "" {
+			continue
+		}
 		clauseKey := getClauseKey(clauseTag)
 		var partialClause string
 		if clauseKey == Subquery {

--- a/marshaller_test.go
+++ b/marshaller_test.go
@@ -745,6 +745,24 @@ var _ = Describe("Marshaller", func() {
 			})
 		})
 
+		Context("when some clauses have soql tags and don't", func() {
+			var criteria QueryCriteriaWithNoSoqlTag
+			BeforeEach(func() {
+				criteria = QueryCriteriaWithNoSoqlTag{
+					NUMAEnabled:   true,
+					DisableAlerts: false,
+				}
+
+				expectedClause = "NUMA_Enabled__c = true"
+			})
+
+			It("returns properly formed clause without error§q", func() {
+				clause, err = MarshalWhereClause(criteria)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(clause).To(Equal(expectedClause))
+			})
+		})
+
 		Context("when all clauses are date time data types", func() {
 			var criteria QueryCriteriaWithDateTimeType
 			var currentTime time.Time

--- a/soql_suite_test.go
+++ b/soql_suite_test.go
@@ -197,6 +197,11 @@ type QueryCriteriaWithBooleanType struct {
 	DisableAlerts bool `soql:"equalsOperator,fieldName=Disable_Alerts__c"`
 }
 
+type QueryCriteriaWithNoSoqlTag struct {
+	NUMAEnabled   bool `soql:"equalsOperator,fieldName=NUMA_Enabled__c"`
+	DisableAlerts bool `json:"random_value"`
+}
+
 type QueryCriteriaWithBooleanPtrType struct {
 	NUMAEnabled   *bool `soql:"equalsOperator,fieldName=NUMA_Enabled__c"`
 	DisableAlerts *bool `soql:"equalsOperator,fieldName=Disable_Alerts__c"`


### PR DESCRIPTION
Gives the flexibility to add non-soql members to the WhereClause. 